### PR TITLE
Minor tweaks as I find them...

### DIFF
--- a/installGenericPKG.sh
+++ b/installGenericPKG.sh
@@ -3,7 +3,7 @@
 #set -x
 #verboseMode=1
 
-scriptVersion="v2.3"
+scriptVersion="v2.2.1"
 
 ##Written by Trevor Sysock (aka @bigmacadmin) at Second Son Consulting Inc.
 #

--- a/installGenericPKG.sh
+++ b/installGenericPKG.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 #set -x
 #verboseMode=1
 
@@ -134,7 +135,7 @@ function debug_message()
 function preinstall_summary_report()
 {
 	echo "$scriptName - $scriptVersion"
-	echo "$(date): "
+	echo "$(date '+%Y%m%dT%H%M%S%z'): "
 	echo "Location: $pathToPKG"
 	echo "Location Type: $pkgLocationType"
 	echo "Expected MD5 is: $expectedMD5"
@@ -220,7 +221,7 @@ elif [ -e "$pathToPKG" ]; then
 	pkgLocationType="filepath"
 else
 	#Some kind of invalid input, not starting with a / or with http. Exit with an error
-	cleanup_and_exit 1 "Path to PKG passed at command line appears to be invalid or undefined."
+	cleanup_and_exit 1 "Path to PKG appears to be invalid or undefined."
 fi
 
 # $2 - The second argument is either an MD5 or a TeamID.

--- a/installGenericPKG.sh
+++ b/installGenericPKG.sh
@@ -1,9 +1,9 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 #set -x
 #verboseMode=1
 
-scriptVersion="v2.2"
+scriptVersion="v2.3"
 
 ##Written by Trevor Sysock (aka @bigmacadmin) at Second Son Consulting Inc.
 #


### PR DESCRIPTION
Aside: I would also think about the rm -r in `rm_if_exists`, but that's only my paranoia as I know `mktemp` is using a path, but I like to cd to a well know directory path and then only rm -r the named remainder of a custom path. (Perhaps I would be worried someone would change the tmp path (i.e. tmpDir) and/or get it wrong and wipe out some parent structure, but I have not edited/suggested the fix in the script for that yet.